### PR TITLE
Escaping core functions

### DIFF
--- a/distributor-remote-quickedit.php
+++ b/distributor-remote-quickedit.php
@@ -185,7 +185,7 @@ function _ajax_wp_die_handler( $message, $title = '', $args = array() ) {
 		die( $message );
 	}
 
-	echo $message;
+	echo esc_html( $message );
 }
 
 

--- a/distributor-remote-quickedit.php
+++ b/distributor-remote-quickedit.php
@@ -19,16 +19,17 @@ namespace Distributor_Remote_Quickedit;
 use function _wp_die_process_input;
 use function add_action;
 use function add_filter;
+use function esc_html;
 use function get_current_screen;
 use function get_post_meta;
 use function get_post_types_by_support;
 use function nocache_headers;
-// use function remove_action;
 use function remove_filter;
 use function restore_current_blog;
 use function status_header;
 use function switch_to_blog;
 use function wp_ajax_inline_save;
+use function wp_die;
 use function wp_parse_args;
 
 const POST_TYPE_SUPPORT = 'distributor-remote-quickedit';

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 # Distributor - Remote Quickedit
 
 Stable tag: 0.2.0  
-Requires at least: 5.9  
+Requires at least: 5.1.0  
 Tested up to: 6.1.1  
-Requires PHP: 7.1  
+Requires PHP: 7.0  
 License: GPL v3 or later  
 Tags: distributor, quickedit  
 Contributors: carstenbach  


### PR DESCRIPTION
[I was wondering what to do ...](#1)

1. Should I just escape my output or can I stay with it because, we know what to expect?

>You escape. Because you're making something new, and you do not know what `$message` will be.

2. Should I create a new ticket on trac, because none of the [11 tickets](https://core.trac.wordpress.org/search?changeset=on&ticket=on&q=_ajax_wp_die_handler) are anyhow related to this issue?

>You could, or you could ask in #core in slack, but keep in mind, plugins aren't core. There are different requirements.

>We understand this is confusing and frustrating. And it even feels horrifically unfair.

>You would be correct. It's not fair, but it's equitable when you consider that the resources are vastly different between you and WordPress core. There's a fundamental difference in the risk between a plugin -- which has a handful, at most, developers -- and WordPress core -- which has hundreds every day.

>If you were to later go back and edit the content of the variable you're echoing to include non-escaped code, then it would make your plugin susceptible to XSS and other similar hacks. And the odds of this happening in your plugin is a magnitude larger than WordPress core.

>This does not mean we believe you are a lesser developer than anyone else, it's simply down to the checks and balances that are different due to the resources available.

>It's incredibly difficult for someone to put it non safely escaped code in core to make those outputs risky. Every commit has to be approved before it goes into core. The odds are someone would catch it first. And if they don't, there are still thousands of automated checks running every day to keep an eye on that stuff.

>On the other hand, it's pretty simple for you to later make a mistake and put in that kind of code. No one from our team will be reviewing your changes. Which means if you don't escape late (i.e. when you echo), and later make a very normal, human, error, you just put everyone who uses your plugin at risk.

>That risk is not worth it. Just think about how much WordPress gets blasted for a security mistake, and how horrible it would be if that was you.

>We do really get we're telling you there are different rules for different people. And yes, in a perfect world, WordPress core would always do things exactly right so there can be no confusion or ambiguity. The real world is never so neat.

>In order to protect your future self, and your users, we need you to properly escape as late as possible. That is, escape when you echo. It will protect you in the long run and, in turn, your users.

Thanks to the great and detailed answer by the [WordPress-Plugin-Review-Team](https://make.wordpress.org/plugins/ )